### PR TITLE
Allow retries on communication exceptions for Aurora ABB Powerone solar inverter

### DIFF
--- a/homeassistant/components/aurora_abb_powerone/__init__.py
+++ b/homeassistant/components/aurora_abb_powerone/__init__.py
@@ -11,8 +11,10 @@
 # sudo chmod 777 /dev/ttyUSB0
 
 import logging
+from time import sleep
 
 from aurorapy.client import AuroraError, AuroraSerialClient, AuroraTimeoutError
+from serial import SerialException
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS, CONF_PORT, Platform
@@ -69,36 +71,43 @@ class AuroraAbbDataUpdateCoordinator(DataUpdateCoordinator[dict[str, float]]):
         """
         data: dict[str, float] = {}
         self.available_prev = self.available
-        try:
-            self.client.connect()
+        retries: int = 3
+        while retries > 0:
+            try:
+                self.client.connect()
 
-            # read ADC channel 3 (grid power output)
-            power_watts = self.client.measure(3, True)
-            temperature_c = self.client.measure(21)
-            energy_wh = self.client.cumulated_energy(5)
-        except AuroraTimeoutError:
-            self.available = False
-            _LOGGER.debug("No response from inverter (could be dark)")
-        except AuroraError as error:
-            self.available = False
-            raise error
-        else:
-            data["instantaneouspower"] = round(power_watts, 1)
-            data["temp"] = round(temperature_c, 1)
-            data["totalenergy"] = round(energy_wh / 1000, 2)
-            self.available = True
-
-        finally:
-            if self.available != self.available_prev:
-                if self.available:
-                    _LOGGER.info("Communication with %s back online", self.name)
-                else:
-                    _LOGGER.warning(
-                        "Communication with %s lost",
-                        self.name,
-                    )
-            if self.client.serline.isOpen():
-                self.client.close()
+                # read ADC channel 3 (grid power output)
+                power_watts = self.client.measure(3, True)
+                temperature_c = self.client.measure(21)
+                energy_wh = self.client.cumulated_energy(5)
+            except AuroraTimeoutError:
+                self.available = False
+                _LOGGER.debug("No response from inverter (could be dark)")
+                retries = 0
+            except (SerialException, AuroraError) as error:
+                self.available = False
+                retries -= 1
+                _LOGGER.warning(
+                    "Exception: %s occurred, %d retries remaining", repr(error), retries
+                )
+                sleep(1)
+            else:
+                data["instantaneouspower"] = round(power_watts, 1)
+                data["temp"] = round(temperature_c, 1)
+                data["totalenergy"] = round(energy_wh / 1000, 2)
+                self.available = True
+                retries = 0
+            finally:
+                if self.available != self.available_prev:
+                    if self.available:
+                        _LOGGER.info("Communication with %s back online", self.name)
+                    else:
+                        _LOGGER.warning(
+                            "Communication with %s lost",
+                            self.name,
+                        )
+                if self.client.serline.isOpen():
+                    self.client.close()
 
         return data
 

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -179,4 +179,4 @@ async def test_sensor_unknown_error(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
         power = hass.states.get("sensor.mydevicename_power_output")
-        assert power is None
+        assert power.state == "unknown"

--- a/tests/components/aurora_abb_powerone/test_sensor.py
+++ b/tests/components/aurora_abb_powerone/test_sensor.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from aurorapy.client import AuroraError, AuroraTimeoutError
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.components.aurora_abb_powerone.const import (
     ATTR_DEVICE_NAME,
@@ -167,7 +168,9 @@ async def test_sensor_dark(hass: HomeAssistant, freezer: FrozenDateTimeFactory) 
         assert power.state == "unknown"  # should this be 'available'?
 
 
-async def test_sensor_unknown_error(hass: HomeAssistant) -> None:
+async def test_sensor_unknown_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test other comms error is handled correctly."""
     mock_entry = _mock_config_entry()
 
@@ -178,5 +181,9 @@ async def test_sensor_unknown_error(hass: HomeAssistant) -> None:
         mock_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
+        assert (
+            "Exception: AuroraError('another error') occurred, 2 retries remaining"
+            in caplog.text
+        )
         power = hass.states.get("sensor.mydevicename_power_output")
         assert power.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following communication problems reported in https://github.com/home-assistant/core/issues/82983, it appears that sometimes errors can occur with the RS485 adaptor.  This PR allows up to 3 retries in the event of an error.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/82983
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
